### PR TITLE
Fixed pennfudan examples and Colab links

### DIFF
--- a/icedata/datasets/pennfudan/README.md
+++ b/icedata/datasets/pennfudan/README.md
@@ -12,7 +12,7 @@ There are 170 images with 345 labeled pedestrians, among which 96 images are tak
 ![image](images/pennfudan_annotations.jpg)
 
 ## Usage 
-<a href="https://colab.research.google.com/github/airctic/icevision/blob/master/notebooks/mask_rcnn_pennfundan.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Example showing how to use this dataset
+<a href="https://colab.research.google.com/github/airctic/icevision/blob/master/notebooks/mask_rcnn_pennfudan.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a> Example showing how to use this dataset
 
 
 ## How to load this dataset
@@ -22,19 +22,19 @@ from icevision.all import *
 import icedata
 
 # Load the PennFudan dataset
-path = icedata.penfundan.load_data()
+path = icedata.pennfudan.load_data()
 ```
 
 ## How to parse this dataset
 ```python
 # Get the class_map, a utility that maps from number IDs to classs names
-class_map = icedata.penfundan.class_map()
+class_map = icedata.pennfudan.class_map()
 
 # Randomly split our data into train/valid
 data_splitter = RandomSplitter([0.8, 0.2])
 
 # PennFudan parser: provided out-of-the-box
-parser = icedata.penfundan.parser(data_dir=path, class_map=class_map)
+parser = icedata.pennfudan.parser(data_dir=path, class_map=class_map)
 train_records, valid_records = parser.parse(data_splitter)
 
 # shows images with corresponding labels and boxes
@@ -43,8 +43,8 @@ show_records(train_records[:6], ncols=3, class_map=class_map, show=True)
 
 ## How to load the pretrained weights of this dataset
 ```python
-class_map = icedata.penfundan.class_map()
-model = icedata.penfundan.trained_models.faster_rcnn_resnet50_fpn()
+class_map = icedata.pennfudan.class_map()
+model = icedata.pennfudan.trained_models.faster_rcnn_resnet50_fpn()
 ```
 
 ## Dataset folders


### PR DESCRIPTION
Fixes #73 

Changes made were:

- [x] Colab Link in Readme.md
- [x] Examples containing the same typo (~pennfundan~ to `pennfudan`)