### PR TITLE
Add voc data functions 

### DIFF
--- a/icedata/datasets/voc/__init__.py
+++ b/icedata/datasets/voc/__init__.py
@@ -1,0 +1,1 @@
+from icedata.datasets.voc.data import *

--- a/icedata/datasets/voc/data.py
+++ b/icedata/datasets/voc/data.py
@@ -1,4 +1,4 @@
-__all__ = ["class_map", "load"]
+__all__ = ["class_map", "load_data"]
 
 from icevision.imports import *
 from icevision.core import *
@@ -34,7 +34,7 @@ def class_map(background: int = 0):
     return ClassMap(classes=_CLASSES, background=background)
 
 
-def load(force_download=False):
+def load_data(force_download=False):
     url = "http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCtrainval_11-May-2012.tar"
 
     save_dir = get_data_dir() / "voc"


### PR DESCRIPTION
I realised that the load_data function could not be accessed from the icedata.voc module so amended the files to make it callable and changed the function name from load to load_data for consistency with the other tutorials. These changes are related to the tutorial I am preparing for icevision issue 'Tutorial for how to use FixedSplitter #585'. 
