### PR TITLE
voc parser

### DIFF
--- a/icedata/datasets/voc/README.md
+++ b/icedata/datasets/voc/README.md
@@ -37,7 +37,8 @@ class_map = icedata.voc.class_map()
 data_splitter = RandomSplitter([0.8, 0.2])
 
 # VOC parser: provided out-of-the-box
-parser = icedata.voc.parser(data_dir=path, class_map=class_map)
+parser = parsers.VOCBBoxParser(annotations_dir= path/'Annotations', images_dir = path/'JPEGImages', class_map=class_map)
+
 train_records, valid_records = parser.parse(data_splitter)
 
 # shows images with corresponding labels and boxes


### PR DESCRIPTION
Previous parser code throws error 'voc has no parser module'.

Changed code to 

parser = parsers.VOCBBoxParser(annotations_dir= path/'Annotations', images_dir = path/'JPEGImages', class_map=class_map)

This one worked for me, so I'm forwarding the suggestion.